### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI Build Stalwart Mail
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/stalwart/security/code-scanning/5](https://github.com/offsoc/stalwart/security/code-scanning/5)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code, clones a public repository, installs dependencies, builds, and uploads an artifact, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file, just after the `name` field and before the `on` field. This will apply the least privilege to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
