### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -1,5 +1,9 @@
 name: Build & Push Multi-Arch Docker Images
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/stalwart/security/code-scanning/4](https://github.com/offsoc/stalwart/security/code-scanning/4)

To fix the problem, you should add a `permissions` block to the workflow, either at the root level (to apply to all jobs) or at the job level (to apply only to the specific job). The minimal required permissions for this workflow are likely `contents: read` (for checking out code) and `packages: write` (for pushing Docker images to GHCR). You should add the following block near the top of the workflow file, after the `name:` and before the `on:` block, or inside the `build-and-push` job definition. The best practice is to add it at the root level so all jobs inherit these permissions unless overridden.

No additional methods, imports, or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
