### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,8 @@ jobs:
 
   macos:
     name: Build / ${{matrix.target}}
+    permissions:
+      contents: read
     runs-on: macos-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/stalwart/security/code-scanning/10](https://github.com/offsoc/stalwart/security/code-scanning/10)

To fix the problem, add a `permissions` block to the `macos` job in `.github/workflows/ci.yml`. The minimal required permission is typically `contents: read`, unless the job needs additional permissions. In this workflow, the `macos` job uses the GITHUB_TOKEN for API calls to download FoundationDB installers, but does not appear to require write access to repository contents or other resources. Therefore, set `permissions: contents: read` for the `macos` job. This change should be made directly under the `macos:` job definition, before the `runs-on:` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
